### PR TITLE
fix: now showing version ids in the frontend too

### DIFF
--- a/frontend/app/composables/useCopyId.ts
+++ b/frontend/app/composables/useCopyId.ts
@@ -1,0 +1,15 @@
+export function useCopyId() {
+  const copiedId = ref<string | null>(null)
+  let timeout: ReturnType<typeof setTimeout> | null = null
+
+  function copyId(key: string, value: string | number) {
+    navigator.clipboard.writeText(String(value))
+    copiedId.value = key
+    if (timeout) clearTimeout(timeout)
+    timeout = setTimeout(
+      () => { copiedId.value = null }, 1500
+    )
+  }
+
+  return { copiedId, copyId }
+}

--- a/frontend/app/pages/projects/[projectId]/[layer]/[resourceId].vue
+++ b/frontend/app/pages/projects/[projectId]/[layer]/[resourceId].vue
@@ -11,6 +11,7 @@ import type {
 
 const route = useRoute()
 const { bronze, silver, gold } = useApi()
+const { copiedId, copyId } = useCopyId()
 
 const projectId = computed(() => Number(route.params.projectId))
 const layer = computed(() => route.params.layer as string)
@@ -229,6 +230,12 @@ function getVersionNumber(
   return 'version' in v ? v.version : v.delta_version
 }
 
+function getDisplayVersion(
+  v: VersionResponse | SilverLineageResponse | GoldLineageResponse
+): number {
+  return 'version' in v ? v.version : v.delta_version + 1
+}
+
 function getStatus(
   v: VersionResponse | SilverLineageResponse | GoldLineageResponse
 ): string | null {
@@ -350,9 +357,19 @@ fetchAll()
           <div class="grid grid-cols-3 gap-4 text-sm">
             <div>
               <span class="text-gray-500 dark:text-gray-400">Resource ID</span>
-              <p class="font-medium text-gray-900 dark:text-white mt-0.5">
-                {{ resource.id }}
-              </p>
+              <div class="flex items-center gap-1 mt-0.5">
+                <p class="font-medium text-gray-900 dark:text-white">
+                  {{ resource.id }}
+                </p>
+                <UButton
+                  :icon="copiedId === `resource-${resource.id}` ? 'i-lucide-check' : 'i-lucide-copy'"
+                  variant="ghost"
+                  color="neutral"
+                  size="xs"
+                  class="size-5 cursor-pointer"
+                  @click="copyId(`resource-${resource.id}`, resource.id)"
+                />
+              </div>
             </div>
             <div>
               <span class="text-gray-500 dark:text-gray-400">Layer</span>
@@ -414,6 +431,9 @@ fetchAll()
                 <th class="text-left py-2.5 px-4 font-medium text-gray-500 dark:text-gray-400 text-xs uppercase tracking-wider">
                   Version
                 </th>
+                <th class="text-left py-2.5 px-4 font-medium text-gray-500 dark:text-gray-400 text-xs uppercase tracking-wider">
+                  ID
+                </th>
                 <th
                   v-if="layer === 'bronze'"
                   class="text-left py-2.5 px-4 font-medium text-gray-500 dark:text-gray-400 text-xs uppercase tracking-wider"
@@ -451,7 +471,23 @@ fetchAll()
                         :name="schemaMap.has(getVersionNumber(v)) ? 'i-lucide-chevron-down' : 'i-lucide-chevron-right'"
                         class="size-3.5 text-gray-400 shrink-0"
                       />
-                      v{{ getVersionNumber(v) }}
+                      v{{ getDisplayVersion(v) }}
+                    </div>
+                  </td>
+                  <td class="py-2.5 px-4">
+                    <div
+                      class="flex items-center gap-1"
+                      @click.stop
+                    >
+                      <span class="font-mono text-gray-500 dark:text-gray-400 text-xs">{{ v.id }}</span>
+                      <UButton
+                        :icon="copiedId === `version-${v.id}` ? 'i-lucide-check' : 'i-lucide-copy'"
+                        variant="ghost"
+                        color="neutral"
+                        size="xs"
+                        class="size-5 cursor-pointer"
+                        @click.stop="copyId(`version-${v.id}`, v.id)"
+                      />
                     </div>
                   </td>
                   <td
@@ -522,7 +558,7 @@ fetchAll()
                   class="border-b border-gray-100 dark:border-gray-800"
                 >
                   <td
-                    :colspan="layer === 'bronze' ? 4 : 4"
+                    :colspan="layer === 'bronze' ? 5 : 5"
                     class="p-4"
                   >
                     <div class="bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-lg overflow-hidden">

--- a/frontend/app/pages/projects/[projectId]/index.vue
+++ b/frontend/app/pages/projects/[projectId]/index.vue
@@ -8,6 +8,7 @@ import type {
 
 const route = useRoute()
 const { projects, bronze, silver, gold } = useApi()
+const { copiedId, copyId } = useCopyId()
 
 const projectId = computed(() => Number(route.params.projectId))
 
@@ -171,6 +172,20 @@ init()
           <h1 class="text-xl font-semibold text-gray-900 dark:text-white">
             {{ project?.name ?? '...' }}
           </h1>
+          <div
+            v-if="project"
+            class="flex items-center gap-0.5 text-xs text-gray-400"
+          >
+            <span class="font-mono">ID: {{ project.id }}</span>
+            <UButton
+              :icon="copiedId === `project-${project.id}` ? 'i-lucide-check' : 'i-lucide-copy'"
+              variant="ghost"
+              color="neutral"
+              size="xs"
+              class="size-5 cursor-pointer"
+              @click="copyId(`project-${project.id}`, project.id)"
+            />
+          </div>
         </div>
         <p
           v-if="project?.description"
@@ -254,6 +269,9 @@ init()
           <thead>
             <tr class="border-b border-gray-200 dark:border-gray-800 bg-gray-50 dark:bg-gray-900/50">
               <th class="text-left py-2.5 px-4 font-medium text-gray-500 dark:text-gray-400 text-xs uppercase tracking-wider">
+                ID
+              </th>
+              <th class="text-left py-2.5 px-4 font-medium text-gray-500 dark:text-gray-400 text-xs uppercase tracking-wider">
                 Name
               </th>
               <th class="text-left py-2.5 px-4 font-medium text-gray-500 dark:text-gray-400 text-xs uppercase tracking-wider">
@@ -274,6 +292,22 @@ init()
               class="border-b border-gray-100 dark:border-gray-800 last:border-0 hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-colors cursor-pointer"
               @click="navigateTo(`/projects/${projectId}/${activeTab}/${resource.id}`)"
             >
+              <td class="py-3 px-4">
+                <div
+                  class="flex items-center gap-1"
+                  @click.stop
+                >
+                  <span class="font-mono text-gray-500 dark:text-gray-400 text-xs">{{ resource.id }}</span>
+                  <UButton
+                    :icon="copiedId === `resource-${resource.id}` ? 'i-lucide-check' : 'i-lucide-copy'"
+                    variant="ghost"
+                    color="neutral"
+                    size="xs"
+                    class="size-5 cursor-pointer"
+                    @click="copyId(`resource-${resource.id}`, resource.id)"
+                  />
+                </div>
+              </td>
               <td class="py-3 px-4">
                 <div class="flex items-center gap-2.5">
                   <div

--- a/frontend/app/pages/projects/index.vue
+++ b/frontend/app/pages/projects/index.vue
@@ -2,6 +2,7 @@
 import type { ProjectResponse } from '~/utils/api'
 
 const { projects } = useApi()
+const { copiedId, copyId } = useCopyId()
 
 const projectList = ref<ProjectResponse[]>([])
 const loading = ref(true)
@@ -100,6 +101,9 @@ fetchProjects()
           <thead>
             <tr class="border-b border-gray-200 dark:border-gray-800 bg-gray-50 dark:bg-gray-900/50">
               <th class="text-left py-2.5 px-4 font-medium text-gray-500 dark:text-gray-400 text-xs uppercase tracking-wider">
+                ID
+              </th>
+              <th class="text-left py-2.5 px-4 font-medium text-gray-500 dark:text-gray-400 text-xs uppercase tracking-wider">
                 Name
               </th>
               <th class="text-left py-2.5 px-4 font-medium text-gray-500 dark:text-gray-400 text-xs uppercase tracking-wider">
@@ -120,6 +124,22 @@ fetchProjects()
               class="border-b border-gray-100 dark:border-gray-800 last:border-0 hover:bg-gray-50 dark:hover:bg-gray-800/50 transition-colors cursor-pointer"
               @click="navigateTo(`/projects/${project.id}`)"
             >
+              <td class="py-3 px-4">
+                <div
+                  class="flex items-center gap-1"
+                  @click.stop
+                >
+                  <span class="font-mono text-gray-500 dark:text-gray-400 text-xs">{{ project.id }}</span>
+                  <UButton
+                    :icon="copiedId === `project-${project.id}` ? 'i-lucide-check' : 'i-lucide-copy'"
+                    variant="ghost"
+                    color="neutral"
+                    size="xs"
+                    class="size-5 cursor-pointer"
+                    @click="copyId(`project-${project.id}`, project.id)"
+                  />
+                </div>
+              </td>
               <td class="py-3 px-4">
                 <div class="flex items-center gap-2.5">
                   <div class="size-8 rounded flex items-center justify-center bg-indigo-500/10 text-indigo-500">


### PR DESCRIPTION
This pull request adds a reusable "copy to clipboard" feature for IDs throughout the project management UI. It introduces a composable to handle copying and feedback, updates tables and detail views to display IDs with a copy button, and ensures a consistent user experience for copying project, resource, and version IDs.

**Copy-to-Clipboard Functionality**

* Added a new composable `useCopyId` that provides a `copyId` method and a `copiedId` state to manage copying IDs and showing feedback (checkmark icon) for 1.5 seconds. (`frontend/app/composables/useCopyId.ts`)
* Integrated `useCopyId` into project, resource, and version listing/detail pages, enabling users to copy IDs (project ID, resource ID, version ID) with a button next to each ID. ([frontend/app/pages/projects/index.vueR5](diffhunk://#diff-1a2d2efd86c8bb735d28faff0599576732631be5180f9b3948180f3bc3287a0fR5), [frontend/app/pages/projects/[projectId]/index.vueR11](diffhunk://#diff-55b3aada510ffeee3091bfecb6df2bf5ab019bc3d1b6024d0d36c4aacabcbf51R11), [frontend/app/pages/projects/[projectId]/[layer]/[resourceId].vueR14](diffhunk://#diff-f0e6270ccbdc1ca0c7a96f7f0ce4e3db61c66b700998208fb17ea913a6068614R14))

**UI Enhancements**

* Updated tables in project lists, project detail, and resource detail views to include an explicit "ID" column, showing IDs in a monospace font with a copy button for each entry. [[1]](diffhunk://#diff-1a2d2efd86c8bb735d28faff0599576732631be5180f9b3948180f3bc3287a0fR103-R105) [[2]](diffhunk://#diff-1a2d2efd86c8bb735d28faff0599576732631be5180f9b3948180f3bc3287a0fR127-R142) [frontend/app/pages/projects/[projectId]/index.vueR271-R273](diffhunk://#diff-55b3aada510ffeee3091bfecb6df2bf5ab019bc3d1b6024d0d36c4aacabcbf51R271-R273), [frontend/app/pages/projects/[projectId]/index.vueR295-R310](diffhunk://#diff-55b3aada510ffeee3091bfecb6df2bf5ab019bc3d1b6024d0d36c4aacabcbf51R295-R310), [frontend/app/pages/projects/[projectId]/[layer]/[resourceId].vueR434-R436](diffhunk://#diff-f0e6270ccbdc1ca0c7a96f7f0ce4e3db61c66b700998208fb17ea913a6068614R434-R436), [frontend/app/pages/projects/[projectId]/[layer]/[resourceId].vueL454-R490](diffhunk://#diff-f0e6270ccbdc1ca0c7a96f7f0ce4e3db61c66b700998208fb17ea913a6068614L454-R490))
* Added copy button for project ID in the project detail page header and for resource ID in the resource detail view. ([frontend/app/pages/projects/[projectId]/index.vueR175-R188](diffhunk://#diff-55b3aada510ffeee3091bfecb6df2bf5ab019bc3d1b6024d0d36c4aacabcbf51R175-R188), [frontend/app/pages/projects/[projectId]/[layer]/[resourceId].vueL353-R372](diffhunk://#diff-f0e6270ccbdc1ca0c7a96f7f0ce4e3db61c66b700998208fb17ea913a6068614L353-R372))

**Other Improvements**

* Added a `getDisplayVersion` helper to correctly display version numbers in the resource detail view. ([frontend/app/pages/projects/[projectId]/[layer]/[resourceId].vueR233-R238](diffhunk://#diff-f0e6270ccbdc1ca0c7a96f7f0ce4e3db61c66b700998208fb17ea913a6068614R233-R238))
* Adjusted table column spans to account for the new ID columns. ([frontend/app/pages/projects/[projectId]/[layer]/[resourceId].vueL525-R561](diffhunk://#diff-f0e6270ccbdc1ca0c7a96f7f0ce4e3db61c66b700998208fb17ea913a6068614L525-R561))